### PR TITLE
make sure the extent range is from -180 to 180

### DIFF
--- a/healpix_plotting/sampling_grid.py
+++ b/healpix_plotting/sampling_grid.py
@@ -198,4 +198,5 @@ class ConcreteSamplingGrid:
 
     @property
     def extent(self):
-        return self.extent_x + self.extent_y
+        extent_x = tuple((x + 180) % 360 - 180 for x in self.extent_x)
+        return extent_x + self.extent_y


### PR DESCRIPTION
Looks like `cartopy` needs values in the range of `]-180,180]` for the `extent`.

cc @jmdelouis